### PR TITLE
Set default agentic option for llama parse

### DIFF
--- a/code/llamaparse.py
+++ b/code/llamaparse.py
@@ -179,7 +179,7 @@ class DocumentConverter:
             api_key=self.api_key,
             result_type="markdown",
             verbose=True,
-            auto_mode=True,  # Automatically choose best parsing mode for each document
+            parse_mode="parse_page_with_agent",
         )
         logger.info("LlamaParse initialized")
         
@@ -200,7 +200,7 @@ class DocumentConverter:
             use_premium = self.should_use_premium_parsing(file_path)
             parser_to_use = self.premium_parser if use_premium else self.parser
             
-            parsing_type = "premium" if use_premium else "auto"
+            parsing_type = "premium" if use_premium else "agentic"
             logger.info(f"Processing ({parsing_type}): {file_path}")
             
             # Parse the document


### PR DESCRIPTION
Set LlamaParse to use agentic parsing by default and update the corresponding log label.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f1a9d50-650d-4875-9159-c031e69fad25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1f1a9d50-650d-4875-9159-c031e69fad25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

